### PR TITLE
Mod Directory Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "belt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "belt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "A fast, cross-platform Factorio benchmarking tool"
 license = "MIT"

--- a/src/benchmark/mod.rs
+++ b/src/benchmark/mod.rs
@@ -14,6 +14,7 @@ pub struct BenchmarkConfig {
     pub pattern: Option<String>,
     pub output: Option<PathBuf>,
     pub template_path: Option<PathBuf>,
+    pub mods_dir: Option<PathBuf>,
 }
 
 pub async fn run(global_config: GlobalConfig, benchmark_config: BenchmarkConfig) -> anyhow::Result<()> {

--- a/src/benchmark/runner.rs
+++ b/src/benchmark/runner.rs
@@ -57,7 +57,10 @@ impl BenchmarkRunner {
     }
 
     async fn run_benchmark_for_save(&self, save_file: &Path) -> Result<BenchmarkResult> {
-        self.sync_mods_for_save(save_file).await?;
+        // If mods_file is not set, sync mods with the given save file
+        if self.config.mods_dir == None {
+            self.sync_mods_for_save(save_file).await?;
+        };
         let log_output = self.execute_factorio_benchmark(save_file).await?;
         let result = parser::parse_benchmark_log(&log_output, save_file, &self.config).map_err(|_| BenchmarkError::ParseError { reason: "".to_string() })?;
         Ok(result)
@@ -104,6 +107,14 @@ impl BenchmarkRunner {
             "--benchmark-runs", &self.config.runs.to_string(),
             "--disable-audio",
         ]);
+
+        if let Some(ref mods_file) = self.config.mods_dir {
+            cmd.arg("--mod-directory");
+            cmd.arg(
+                mods_file.to_str().ok_or_else(|| BenchmarkError::InvalidModsFileName { path: mods_file.clone() })?
+            );
+        }
+
 
         cmd.stdout(Stdio::piped())
            .stderr(Stdio::piped());

--- a/src/benchmark/runner.rs
+++ b/src/benchmark/runner.rs
@@ -61,6 +61,7 @@ impl BenchmarkRunner {
         if self.config.mods_dir == None {
             self.sync_mods_for_save(save_file).await?;
         };
+
         let log_output = self.execute_factorio_benchmark(save_file).await?;
         let result = parser::parse_benchmark_log(&log_output, save_file, &self.config).map_err(|_| BenchmarkError::ParseError { reason: "".to_string() })?;
         Ok(result)
@@ -108,13 +109,12 @@ impl BenchmarkRunner {
             "--disable-audio",
         ]);
 
-        if let Some(ref mods_file) = self.config.mods_dir {
+        if let Some(mods_file) = &self.config.mods_dir {
             cmd.arg("--mod-directory");
             cmd.arg(
                 mods_file.to_str().ok_or_else(|| BenchmarkError::InvalidModsFileName { path: mods_file.clone() })?
             );
         }
-
 
         cmd.stdout(Stdio::piped())
            .stderr(Stdio::piped());

--- a/src/benchmark/runner.rs
+++ b/src/benchmark/runner.rs
@@ -114,6 +114,7 @@ impl BenchmarkRunner {
             cmd.arg(
                 mods_file.to_str().ok_or_else(|| BenchmarkError::InvalidModsFileName { path: mods_file.clone() })?
             );
+            tracing::debug!("Set the mod list to: {}", mods_file.display());
         }
 
         cmd.stdout(Stdio::piped())

--- a/src/core/config.rs
+++ b/src/core/config.rs
@@ -11,7 +11,7 @@ impl Default for GlobalConfig {
     fn default() -> Self {
         Self {
             factorio_path: None,
-            verbose: false,
+            verbose: false
         }
     }
 }

--- a/src/core/error.rs
+++ b/src/core/error.rs
@@ -21,6 +21,9 @@ pub enum BenchmarkError {
     #[error("Invalid save file name: {path}")]
     InvalidSaveFileName { path: PathBuf },
 
+    #[error("Invalid mods file name: {path}")]
+    InvalidModsFileName { path: PathBuf },
+
     #[error("Invalid UTF-8 in Factorio output")]
     InvalidUtf8Output,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,9 @@ enum Commands {
 
         #[arg(long)] 
         template_path: Option<PathBuf>,
+
+        #[arg(long)] 
+        mods_dir: Option<PathBuf>,
     },
 }
 
@@ -61,7 +64,7 @@ async fn main() -> Result<()> {
     };
 
     match cli.command {
-        Commands::Benchmark { saves_dir, ticks, runs, pattern, output, template_path } => {
+        Commands::Benchmark { saves_dir, ticks, runs, pattern, output, template_path, mods_dir } => {
             let benchmark_config = benchmark::BenchmarkConfig {
                 saves_dir,
                 ticks,
@@ -69,6 +72,7 @@ async fn main() -> Result<()> {
                 pattern,
                 output,
                 template_path,
+                mods_dir,
             };
 
             benchmark::run(global_config, benchmark_config).await?;


### PR DESCRIPTION
- adds option for `--mods-dir`
- populates the factorio bin with the argument of `--mod-directory` and the passed in path
- if not specified, falls back to syncing the mods with the save file